### PR TITLE
Add install packaging support for oh-my-dear-imgui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,29 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/omdi)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
+
+include(CMakePackageConfigHelpers)
+
+set(INSTALL_CONFIGDIR lib/cmake/oh-my-dear-imgui)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/oh-my-dear-imguiConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfig.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(
+  EXPORT oh-my-dear-imguiTargets
+  NAMESPACE oh-my-dear-imgui::
+  FILE oh-my-dear-imguiTargets.cmake
+  DESTINATION ${INSTALL_CONFIGDIR})
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfigVersion.cmake
+  DESTINATION ${INSTALL_CONFIGDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,17 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/omdi)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
+
+set(omdi_BUILD_EXAMPLES
+    "OFF"
+    CACHE BOOL "Build omdi examples")
+
+if(${omdi_BUILD_EXAMPLES})
+  message(STATUS "Building examples")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
+else()
+  message(STATUS "Skipping examples")
+endif()
 
 include(CMakePackageConfigHelpers)
 
@@ -35,8 +45,6 @@ install(
   FILE oh-my-dear-imguiTargets.cmake
   DESTINATION ${INSTALL_CONFIGDIR})
 
-install(
-  FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfigVersion.cmake
-  DESTINATION ${INSTALL_CONFIGDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/oh-my-dear-imguiConfigVersion.cmake
+        DESTINATION ${INSTALL_CONFIGDIR})

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ A bit more than minimal wrapper library for ImGui-based applications.
 Add the library as a dependency to your app in your `CMakeLists.txt`:
 
 ```cmake
+find_package(oh-my-dear-imgui CONFIG REQUIRED)
+
+set(EXEC main)
+set(SRC main.cpp)
+add_executable(${EXEC} ${SRC})
+
+target_link_libraries(${EXEC} PRIVATE oh-my-dear-imgui::oh-my-dear-imgui)
+```
+
+Alternatively, you can fetch OMDI as part of your build using `FetchContent`:
+
+```cmake
 set(FETCHCONTENT_QUIET FALSE)
 include(FetchContent)
 FetchContent_Declare(
@@ -17,16 +29,12 @@ FetchContent_Declare(
   GIT_TAG master
   GIT_PROGRESS TRUE)
 FetchContent_MakeAvailable(oh-my-dear-imgui)
-```
 
-Then simply link with it:
-
-```cmake
 set(EXEC main)
 set(SRC main.cpp)
 add_executable(${EXEC} ${SRC})
 
-target_link_libraries(${EXEC} PRIVATE oh-my-dear-imgui)
+target_link_libraries(${EXEC} PRIVATE oh-my-dear-imgui::oh-my-dear-imgui)
 ```
 
 ### Using in applications

--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ A bit more than minimal wrapper library for ImGui-based applications.
 
 ### Cross-compiling OMDI
 
-Add the library as a dependency to your app in your `CMakeLists.txt`:
+#### Pre-installing
+
+You can compile and install `oh-my-dear-imgui`:
+
+```sh
+cmake -B build -D CMAKE_INSTALL_PREFIX=/install-path-for/omdi/
+cmake --build build --config Release -j
+cmake --install build
+```
+
+Add the library as a dependency to your app:
 
 ```cmake
 find_package(oh-my-dear-imgui CONFIG REQUIRED)
@@ -18,7 +28,15 @@ add_executable(${EXEC} ${SRC})
 target_link_libraries(${EXEC} PRIVATE oh-my-dear-imgui::oh-my-dear-imgui)
 ```
 
-Alternatively, you can fetch OMDI as part of your build using `FetchContent`:
+Then simply point to the install directory when compiling your application:
+
+```sh
+cmake -B build -D CMAKE_PREFIX_PATH=/install-path-for/omdi/
+```
+
+#### In-tree building
+
+Alternatively, you can fetch OMDI as part of your build using `FetchContent` to build the library in-tree:
 
 ```cmake
 set(FETCHCONTENT_QUIET FALSE)
@@ -95,7 +113,7 @@ app.Render(
 A few standalone examples can be found in the `examples/` directory. These can be compiled using simply:
 
 ```sh
-cmake -B build
+cmake -B build -D omdi_BUILD_EXAMPLES=ON
 cmake --build build -j
 ```
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -357,6 +357,21 @@ if(TARGET implot)
       PATTERN "*.inl")
 endif()
 
+if(TARGET toml11)
+  target_include_directories(
+    toml11
+    PUBLIC
+      "$<BUILD_INTERFACE:${toml11_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>")
+  install(
+    TARGETS toml11
+    EXPORT oh-my-dear-imguiTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+endif()
+
 if(EXISTS ${plog_SOURCE_DIR}/include)
   install(DIRECTORY ${plog_SOURCE_DIR}/include/ DESTINATION include)
 endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -314,62 +314,63 @@ if(TARGET imgui)
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include/imgui)
+    INCLUDES
+    DESTINATION include/imgui)
   install(
     DIRECTORY ${imgui_SOURCE_DIR}/
     DESTINATION include/imgui
     FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hpp"
-      PATTERN "*.inl")
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.inl")
 endif()
 
 if(TARGET imgui_backends)
   target_include_directories(
-    imgui_backends
-    PUBLIC
-      "$<INSTALL_INTERFACE:include/imgui>"
-      "$<INSTALL_INTERFACE:include/imgui/backends>")
+    imgui_backends PUBLIC "$<INSTALL_INTERFACE:include/imgui>"
+                          "$<INSTALL_INTERFACE:include/imgui/backends>")
   install(
     TARGETS imgui_backends
     EXPORT oh-my-dear-imguiTargets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include/imgui)
+    INCLUDES
+    DESTINATION include/imgui)
 endif()
 
 if(TARGET implot)
-  target_include_directories(implot PUBLIC "$<INSTALL_INTERFACE:include/implot>")
+  target_include_directories(implot
+                             PUBLIC "$<INSTALL_INTERFACE:include/implot>")
   install(
     TARGETS implot
     EXPORT oh-my-dear-imguiTargets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include/implot)
+    INCLUDES
+    DESTINATION include/implot)
   install(
     DIRECTORY ${implot_SOURCE_DIR}/
     DESTINATION include/implot
     FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hpp"
-      PATTERN "*.inl")
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.inl")
 endif()
 
 if(TARGET toml11)
   target_include_directories(
-    toml11
-    PUBLIC
-      "$<BUILD_INTERFACE:${toml11_SOURCE_DIR}/include>"
-      "$<INSTALL_INTERFACE:include>")
+    toml11 PUBLIC "$<BUILD_INTERFACE:${toml11_SOURCE_DIR}/include>"
+                  "$<INSTALL_INTERFACE:include>")
   install(
     TARGETS toml11
     EXPORT oh-my-dear-imguiTargets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include)
+    INCLUDES
+    DESTINATION include)
 endif()
 
 if(EXISTS ${plog_SOURCE_DIR}/include)
@@ -385,9 +386,9 @@ if(EXISTS ${stb_SOURCE_DIR})
     DIRECTORY ${stb_SOURCE_DIR}/
     DESTINATION include
     FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hpp"
-      PATTERN "*.inl")
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.inl")
 endif()
 
 if(EXISTS ${ImGuiFileDialog_SOURCE_DIR})
@@ -395,8 +396,8 @@ if(EXISTS ${ImGuiFileDialog_SOURCE_DIR})
     DIRECTORY ${ImGuiFileDialog_SOURCE_DIR}/
     DESTINATION include/ImGuiFileDialog
     FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hpp")
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 endif()
 
 set(LIBRARIES

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -264,7 +264,9 @@ function(
   if(NOT "${full_src_files}" STREQUAL "")
     add_library("${name}" "${full_src_files}")
     if(NOT "${inc_dirs}" STREQUAL "")
-      target_include_directories("${name}" PUBLIC "${inc_dirs}")
+      foreach(dir ${inc_dirs})
+        target_include_directories("${name}" PUBLIC "$<BUILD_INTERFACE:${dir}>")
+      endforeach()
     endif()
     if(NOT "${links}" STREQUAL "")
       target_link_libraries("${name}" "${links}")
@@ -303,6 +305,84 @@ build_library(imgui_backends "${imgui_backends_SRC_FILES}"
               "${imgui_SOURCE_DIR};${imgui_backends_SOURCE_DIR}" "glfw" "" "")
 build_library(implot "${implot_SRC_FILES}"
               "${implot_SOURCE_DIR};${imgui_SOURCE_DIR}" "imgui" "" "")
+
+if(TARGET imgui)
+  target_include_directories(imgui PUBLIC "$<INSTALL_INTERFACE:include/imgui>")
+  install(
+    TARGETS imgui
+    EXPORT oh-my-dear-imguiTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include/imgui)
+  install(
+    DIRECTORY ${imgui_SOURCE_DIR}/
+    DESTINATION include/imgui
+    FILES_MATCHING
+      PATTERN "*.h"
+      PATTERN "*.hpp"
+      PATTERN "*.inl")
+endif()
+
+if(TARGET imgui_backends)
+  target_include_directories(
+    imgui_backends
+    PUBLIC
+      "$<INSTALL_INTERFACE:include/imgui>"
+      "$<INSTALL_INTERFACE:include/imgui/backends>")
+  install(
+    TARGETS imgui_backends
+    EXPORT oh-my-dear-imguiTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include/imgui)
+endif()
+
+if(TARGET implot)
+  target_include_directories(implot PUBLIC "$<INSTALL_INTERFACE:include/implot>")
+  install(
+    TARGETS implot
+    EXPORT oh-my-dear-imguiTargets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include/implot)
+  install(
+    DIRECTORY ${implot_SOURCE_DIR}/
+    DESTINATION include/implot
+    FILES_MATCHING
+      PATTERN "*.h"
+      PATTERN "*.hpp"
+      PATTERN "*.inl")
+endif()
+
+if(EXISTS ${plog_SOURCE_DIR}/include)
+  install(DIRECTORY ${plog_SOURCE_DIR}/include/ DESTINATION include)
+endif()
+
+if(EXISTS ${toml11_SOURCE_DIR}/include)
+  install(DIRECTORY ${toml11_SOURCE_DIR}/include/ DESTINATION include)
+endif()
+
+if(EXISTS ${stb_SOURCE_DIR})
+  install(
+    DIRECTORY ${stb_SOURCE_DIR}/
+    DESTINATION include
+    FILES_MATCHING
+      PATTERN "*.h"
+      PATTERN "*.hpp"
+      PATTERN "*.inl")
+endif()
+
+if(EXISTS ${ImGuiFileDialog_SOURCE_DIR})
+  install(
+    DIRECTORY ${ImGuiFileDialog_SOURCE_DIR}/
+    DESTINATION include/ImGuiFileDialog
+    FILES_MATCHING
+      PATTERN "*.h"
+      PATTERN "*.hpp")
+endif()
 
 set(LIBRARIES
     "${LIBS}"

--- a/cmake/oh-my-dear-imguiConfig.cmake.in
+++ b/cmake/oh-my-dear-imguiConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(OpenGL REQUIRED)
+find_dependency(glfw3 REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/oh-my-dear-imguiTargets.cmake")
+
+check_required_components(oh-my-dear-imgui)

--- a/omdi/CMakeLists.txt
+++ b/omdi/CMakeLists.txt
@@ -14,22 +14,22 @@ endif()
 target_link_libraries(${LIB} PUBLIC ${LIBS})
 target_include_directories(
   ${LIB}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/style>
-    $<BUILD_INTERFACE:${stb_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${plog_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${ImGuiFileDialog_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${implot_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include/oh-my-dear-imgui>
-    $<INSTALL_INTERFACE:include>
-    $<INSTALL_INTERFACE:include/imgui>
-    $<INSTALL_INTERFACE:include/implot>
-    $<INSTALL_INTERFACE:include/ImGuiFileDialog>)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/style>
+         $<BUILD_INTERFACE:${stb_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${plog_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${ImGuiFileDialog_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${implot_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:include/oh-my-dear-imgui>
+         $<INSTALL_INTERFACE:include>
+         $<INSTALL_INTERFACE:include/imgui>
+         $<INSTALL_INTERFACE:include/implot>
+         $<INSTALL_INTERFACE:include/ImGuiFileDialog>)
 
 target_compile_definitions(
-  ${LIB} PUBLIC CUSTOM_IMGUIFILEDIALOG_CONFIG="style/imgui_file_dialog_config.h")
+  ${LIB}
+  PUBLIC CUSTOM_IMGUIFILEDIALOG_CONFIG="style/imgui_file_dialog_config.h")
 
 install(
   TARGETS ${LIB}
@@ -37,14 +37,15 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include/oh-my-dear-imgui)
+  INCLUDES
+  DESTINATION include/oh-my-dear-imgui)
 
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
   DESTINATION include/oh-my-dear-imgui
   FILES_MATCHING
-    PATTERN "*.h"
-    PATTERN "*.hpp")
+  PATTERN "*.h"
+  PATTERN "*.hpp")
 
 set(${LIB}_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/omdi/CMakeLists.txt
+++ b/omdi/CMakeLists.txt
@@ -2,9 +2,6 @@
 
 set(LIB ${PROJECT_NAME})
 set(LIBS "${LIBRARIES};glfw;OpenGL::GL")
-set(INC_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/style
-    ${stb_SOURCE_DIR}/ ${plog_SOURCE_DIR}/include ${ImGuiFileDialog_SOURCE_DIR})
 
 file(GLOB_RECURSE SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 list(FILTER SRC EXCLUDE REGEX "assets")
@@ -15,12 +12,39 @@ if(NOT TARGET ${PROJECT_NAME}::${PROJECT_NAME})
   add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${LIB})
 endif()
 target_link_libraries(${LIB} PUBLIC ${LIBS})
-target_include_directories(${LIB} PUBLIC ${INC_DIRS})
+target_include_directories(
+  ${LIB}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/style>
+    $<BUILD_INTERFACE:${stb_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${plog_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${ImGuiFileDialog_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${implot_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/oh-my-dear-imgui>
+    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/imgui>
+    $<INSTALL_INTERFACE:include/implot>
+    $<INSTALL_INTERFACE:include/ImGuiFileDialog>)
 
-set(imgui_file_dialog_config
-    "${CMAKE_CURRENT_SOURCE_DIR}/style/imgui_file_dialog_config.h")
 target_compile_definitions(
-  ${LIB} PUBLIC -DCUSTOM_IMGUIFILEDIALOG_CONFIG="${imgui_file_dialog_config}")
+  ${LIB} PUBLIC CUSTOM_IMGUIFILEDIALOG_CONFIG="style/imgui_file_dialog_config.h")
+
+install(
+  TARGETS ${LIB}
+  EXPORT oh-my-dear-imguiTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include/oh-my-dear-imgui)
+
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+  DESTINATION include/oh-my-dear-imgui
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 
 set(${LIB}_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
## Summary
- install the main library and headers while exporting an oh-my-dear-imgui CMake package
- add install rules for the helper ImGui libraries and ship their public headers
- document CMake `find_package` usage for consumers

## Testing
- cmake -S . -B build *(fails: missing glfw3 package in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69112d537c8c832395864b04cb7b93ee)